### PR TITLE
Vita: Add example usage

### DIFF
--- a/ManiaTouchControls/CMakeLists.txt
+++ b/ManiaTouchControls/CMakeLists.txt
@@ -6,12 +6,25 @@ set(MOD_NAME ManiaTouchControls CACHE STRING "The mod directory to look into")
 
 set(OUTPUT_NAME "ManiaTouchControls" CACHE STRING "The name of the built library")
 
-add_library(ManiaTouchControls SHARED
-    GameAPI/C/GameAPI/Game.c
-    ${MOD_NAME}/dllmain.c
-    ${MOD_NAME}/Helpers.c
-    ${MOD_NAME}/Objects/All.c
+set(sources
+  GameAPI/C/GameAPI/Game.c
+  ${MOD_NAME}/dllmain.c
+  ${MOD_NAME}/Helpers.c
+  ${MOD_NAME}/Objects/All.c
 )
+
+if (VITA)
+    set(VITASDK_CMAKE_FILE "$ENV{VITASDK}/share/vita.cmake" CACHE PATH "VitaSDK CMake functions file")
+    include("${VITASDK_CMAKE_FILE}" REQUIRED)
+
+    add_executable(ManiaTouchControls
+        ${sources}
+    )
+else()
+    add_library(ManiaTouchControls SHARED
+        ${sources}
+    )
+endif()
 
 target_include_directories(ManiaTouchControls PRIVATE
     ${MOD_NAME}/
@@ -20,6 +33,13 @@ target_include_directories(ManiaTouchControls PRIVATE
 )
 
 set_target_properties(ManiaTouchControls PROPERTIES OUTPUT_NAME ${OUTPUT_NAME})
+
+if (VITA)
+    vita_create_self(${OUTPUT_NAME}.suprx ${MOD_NAME}
+      GEN_EXPORTS export.yml    # This is required or else nothing will be exported
+      UNSAFE
+    )
+endif()
 
 unset(MOD_NAME CACHE)
 unset(OUTPUT_NAME CACHE)

--- a/ManiaTouchControls/ManiaTouchControls/dllmain.c
+++ b/ManiaTouchControls/ManiaTouchControls/dllmain.c
@@ -140,3 +140,9 @@ bool32 LinkModLogic(EngineInfo *info, const char *id)
     return true;
 }
 #endif
+
+#ifdef __vita__
+void main() __attribute__ ((weak, alias ("module_start")));
+int module_start(int argc, const void *args) {};
+int module_stop(int argc, const void *args) {};
+#endif

--- a/UltrawideMania/CMakeLists.txt
+++ b/UltrawideMania/CMakeLists.txt
@@ -6,11 +6,24 @@ set(MOD_NAME UltrawideMania CACHE STRING "The mod directory to look into")
 
 set(OUTPUT_NAME "UltrawideMania" CACHE STRING "The name of the built library")
 
-add_library(UltrawideMania SHARED
+set(sources
     GameAPI/C/GameAPI/Game.c
     ${MOD_NAME}/dllmain.c
     ${MOD_NAME}/Objects/All.c
 )
+
+if (VITA)
+    set(VITASDK_CMAKE_FILE "$ENV{VITASDK}/share/vita.cmake" CACHE PATH "VitaSDK CMake functions file")
+    include("${VITASDK_CMAKE_FILE}" REQUIRED)
+
+    add_executable(UltrawideMania
+        ${sources}
+    )
+else()
+    add_library(UltrawideMania SHARED
+        ${sources}
+    )
+endif()
 
 target_include_directories(UltrawideMania PRIVATE
     ${MOD_NAME}/
@@ -19,6 +32,13 @@ target_include_directories(UltrawideMania PRIVATE
 )
 
 set_target_properties(UltrawideMania PROPERTIES OUTPUT_NAME ${OUTPUT_NAME})
+
+if (VITA)
+    vita_create_self(${OUTPUT_NAME}.suprx ${MOD_NAME}
+      GEN_EXPORTS export.yml    # This is required or else nothing will be exported
+      UNSAFE
+    )
+endif()
 
 unset(MOD_NAME CACHE)
 unset(OUTPUT_NAME CACHE)

--- a/UltrawideMania/UltrawideMania/dllmain.c
+++ b/UltrawideMania/UltrawideMania/dllmain.c
@@ -65,3 +65,9 @@ bool32 LinkModLogic(EngineInfo *info, const char *id)
     return true;
 }
 #endif
+
+#ifdef __vita__
+void main() __attribute__ ((weak, alias ("module_start")));
+int module_start(int argc, const void *args) {};
+int module_stop(int argc, const void *args) {};
+#endif


### PR DESCRIPTION
Minor changes to the CMake and `dllmain` files to show everything that is needed for Vita support, being a non-standard system.

Only for UltrawideMania and ManiaTouchControls.