### PR TITLE
Fix crash when returning to main menu in UltrawideMania

### DIFF
--- a/UltrawideMania/UltrawideMania/Objects/Menu/MainMenu.c
+++ b/UltrawideMania/UltrawideMania/Objects/Menu/MainMenu.c
@@ -3,7 +3,7 @@ ObjectMainMenu *MainMenu;
 
 void MainMenu_StaticUpdate(void)
 {
-    if (MainMenu->menuControl && MainMenu->menuControl->active) {
+    if (MainMenu->menuControl) {
         foreach_all(UIDiorama, diorama)
         {
             int32 x = MainMenu->menuControl->startPos.x - MainMenu->menuControl->cameraOffset.x;

--- a/UltrawideMania/UltrawideMania/Objects/Menu/UIDiorama.c
+++ b/UltrawideMania/UltrawideMania/Objects/Menu/UIDiorama.c
@@ -2,12 +2,6 @@
 
 ObjectUIDiorama *UIDiorama;
 
-void UIDiorama_Update(void) {
-    Mod.Super(UIDiorama->classID, SUPER_UPDATE, NULL);    
-
-    RSDK_THIS(UIDiorama);
-}
-
 void UIDiorama_Create(void* data)
 {
     RSDK_THIS(UIDiorama);

--- a/UltrawideMania/UltrawideMania/Objects/Menu/UIDiorama.h
+++ b/UltrawideMania/UltrawideMania/Objects/Menu/UIDiorama.h
@@ -44,7 +44,6 @@ struct EntityUIDiorama {
 // Object Struct
 extern ObjectUIDiorama *UIDiorama;
 
-void UIDiorama_Update(void);
 void UIDiorama_Create(void* data);
 
 #endif

--- a/UltrawideMania/UltrawideMania/dllmain.c
+++ b/UltrawideMania/UltrawideMania/dllmain.c
@@ -24,7 +24,7 @@ void InitModAPI(void)
     // Setup Config
     Mod.SaveSettings();
 
-    MOD_REGISTER_OBJ_OVERLOAD(UIDiorama, UIDiorama_Update, NULL, NULL, NULL, UIDiorama_Create, NULL, NULL, NULL, NULL);
+    MOD_REGISTER_OBJ_OVERLOAD(UIDiorama, NULL, NULL, NULL, NULL, UIDiorama_Create, NULL, NULL, NULL, NULL);
     MOD_REGISTER_OBJ_OVERLOAD(MainMenu, NULL, NULL, MainMenu_StaticUpdate, NULL, NULL, NULL, NULL, NULL, NULL);
 
     MathHelpers_PointInHitbox = Mod.GetPublicFunction(NULL, "MathHelpers_PointInHitbox");


### PR DESCRIPTION
Should fix #6, also removes a redundant event overload