### PR TITLE
Fix OOZ2 Outro not being skippable with ManiaTouchControls

### DIFF
--- a/ManiaTouchControls/ManiaTouchControls/ManiaTouchControls.vcxproj
+++ b/ManiaTouchControls/ManiaTouchControls/ManiaTouchControls.vcxproj
@@ -185,6 +185,7 @@
     <ClCompile Include="Objects\FXFade.c" />
     <ClCompile Include="Objects\HUD.c" />
     <ClCompile Include="Objects\LevelSelect.c" />
+    <ClCompile Include="Objects\OOZ2Outro.c" />
     <ClCompile Include="Objects\PBL_Crane.c" />
     <ClCompile Include="Objects\PBL_Flipper.c" />
     <ClCompile Include="Objects\PBL_HUD.c" />
@@ -224,6 +225,7 @@
     <ClInclude Include="Objects\FXFade.h" />
     <ClInclude Include="Objects\HUD.h" />
     <ClInclude Include="Objects\LevelSelect.h" />
+    <ClInclude Include="Objects\OOZ2Outro.h" />
     <ClInclude Include="Objects\PBL_Crane.h" />
     <ClInclude Include="Objects\PBL_Flipper.h" />
     <ClInclude Include="Objects\PBL_HUD.h" />

--- a/ManiaTouchControls/ManiaTouchControls/ManiaTouchControls.vcxproj.filters
+++ b/ManiaTouchControls/ManiaTouchControls/ManiaTouchControls.vcxproj.filters
@@ -112,6 +112,9 @@
     <ClCompile Include="Objects\SpecialClear.c">
       <Filter>Source Files\Objects</Filter>
     </ClCompile>
+    <ClCompile Include="Objects\OOZ2Outro.c">
+      <Filter>Source Files\Objects</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Objects\Player.h">
@@ -223,6 +226,9 @@
       <Filter>Source Files\Objects</Filter>
     </ClInclude>
     <ClInclude Include="Objects\SpecialClear.h">
+      <Filter>Source Files\Objects</Filter>
+    </ClInclude>
+    <ClInclude Include="Objects\OOZ2Outro.h">
       <Filter>Source Files\Objects</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ManiaTouchControls/ManiaTouchControls/Objects/All.c
+++ b/ManiaTouchControls/ManiaTouchControls/Objects/All.c
@@ -28,3 +28,4 @@
 #include "Objects/LevelSelect.c"
 #include "Objects/SpecialClear.c"
 #include "Objects/FXFade.c"
+#include "Objects/OOZ2Outro.c"

--- a/ManiaTouchControls/ManiaTouchControls/Objects/CutsceneSeq.c
+++ b/ManiaTouchControls/ManiaTouchControls/Objects/CutsceneSeq.c
@@ -1,32 +1,23 @@
 #include "CutsceneSeq.h"
 
 #if MANIA_USE_PLUS
-
-void (*CutsceneSeq_CheckSkip)(uint8 skipType, EntityCutsceneSeq *seq, void (*skipCallback)(void)) = NULL;
+ObjectCutsceneSeq *CutsceneSeq;
 
 void CutsceneSeq_Update(void)
 {
     RSDK_THIS(CutsceneSeq);
 
-    CutsceneSeq_CheckSkip_Hook(self->skipType, self, self->skipCallback);
+    ControllerInfo->keyStart.press |= TouchInfo->count;
+
+    Mod.Super(CutsceneSeq->classID, SUPER_UPDATE, NULL);
 }
 
 void CutsceneSeq_Create(void *data)
 {
     RSDK_THIS(CutsceneSeq);
 
-    Object *cutSeq = Mod.FindObject("CutsceneSeq");
-
-    Mod.Super(cutSeq->classID, SUPER_CREATE, data);
-
-    CutsceneSeq_CheckSkip_Hook(self->skipType, self, self->skipCallback);
-}
-
-void CutsceneSeq_CheckSkip_Hook(uint8 skipType, EntityCutsceneSeq *seq, void (*skipCallback)(void))
-{
     ControllerInfo->keyStart.press |= TouchInfo->count;
 
-    if (CutsceneSeq_CheckSkip)
-        CutsceneSeq_CheckSkip(skipType, seq, skipCallback);
+    Mod.Super(CutsceneSeq->classID, SUPER_CREATE, data);
 }
 #endif

--- a/ManiaTouchControls/ManiaTouchControls/Objects/CutsceneSeq.h
+++ b/ManiaTouchControls/ManiaTouchControls/Objects/CutsceneSeq.h
@@ -14,6 +14,11 @@ typedef enum {
 } SkipTypes;
 #endif
 
+// Object Class
+typedef struct {
+    RSDK_OBJECT
+} ObjectCutsceneSeq;
+
 // Entity Class
 typedef struct {
     RSDK_ENTITY
@@ -35,17 +40,12 @@ typedef struct {
 #endif
 } EntityCutsceneSeq;
 
+extern ObjectCutsceneSeq *CutsceneSeq;
+
 #if MANIA_USE_PLUS
-
-// Public Functions
-extern void (*CutsceneSeq_CheckSkip)(uint8 skipType, EntityCutsceneSeq *seq, void (*skipCallback)(void));
-
 // Standard Entity Events
 void CutsceneSeq_Update(void);
 void CutsceneSeq_Create(void *data);
-
-// Extra Entity Functions
-void CutsceneSeq_CheckSkip_Hook(uint8 skipType, EntityCutsceneSeq *seq, void (*skipCallback)(void));
 #endif
 
 #endif //! OBJ_CUTSCENESEQ_H

--- a/ManiaTouchControls/ManiaTouchControls/Objects/OOZ2Outro.c
+++ b/ManiaTouchControls/ManiaTouchControls/Objects/OOZ2Outro.c
@@ -1,0 +1,18 @@
+#include "GameAPI/Game.h"
+
+#if MANIA_USE_PLUS
+StateMachine(OOZ2Outro_State_BoardSub) = NULL;
+StateMachine(OOZ2Outro_State_SubActivate) = NULL;
+
+void OOZ2Outro_State_BoardSub_Hook(void)
+{
+    ControllerInfo->keyStart.press |= TouchInfo->count;
+    return false;
+}
+
+void OOZ2Outro_State_SubActivate_Hook(void)
+{
+    ControllerInfo->keyStart.press |= TouchInfo->count;
+    return false;
+}
+#endif

--- a/ManiaTouchControls/ManiaTouchControls/Objects/OOZ2Outro.h
+++ b/ManiaTouchControls/ManiaTouchControls/Objects/OOZ2Outro.h
@@ -1,0 +1,16 @@
+#ifndef OBJ_OOZ2OUTRO_H
+#define OBJ_OOZ2OUTRO_H
+
+#include "GameAPI/Game.h"
+
+#if MANIA_USE_PLUS
+// Extra Entity Functions
+extern StateMachine(OOZ2Outro_State_BoardSub);
+extern StateMachine(OOZ2Outro_State_SubActivate);
+
+// State Hooks
+void OOZ2Outro_State_BoardSub_Hook(void);
+void OOZ2Outro_State_SubActivate_Hook(void);
+#endif
+
+#endif //! OBJ_OOZ2OUTRO_H

--- a/ManiaTouchControls/ManiaTouchControls/dllmain.c
+++ b/ManiaTouchControls/ManiaTouchControls/dllmain.c
@@ -29,6 +29,7 @@
 #include "Objects/TitleSetup.h"
 #include "Objects/UIVideo.h"
 #include "Objects/UIControl.h"
+#include "Objects/OOZ2Outro.h"
 
 ModConfig config;
 
@@ -61,6 +62,8 @@ void InitModAPI(void)
     Gachapandora_Player_StateInput_P1Grabbed = Mod.GetPublicFunction(NULL, "Gachapandora_Player_StateInput_P1Grabbed");
 #if MANIA_USE_PLUS
     EncoreIntro_PlayerInput_BuddySel = Mod.GetPublicFunction(NULL, "EncoreIntro_PlayerInput_BuddySel");
+    OOZ2Outro_State_BoardSub         = Mod.GetPublicFunction(NULL, "OOZ2Outro_State_BoardSub");
+    OOZ2Outro_State_SubActivate      = Mod.GetPublicFunction(NULL, "OOZ2Outro_State_SubActivate");
 #endif
 
     BSS_Player_Input_P1   = Mod.GetPublicFunction(NULL, "BSS_Player_Input_P1");
@@ -87,6 +90,8 @@ void InitModAPI(void)
     Mod.RegisterStateHook(Gachapandora_Player_StateInput_P1Grabbed, Player_Input_P1_Hook, true);
 #if MANIA_USE_PLUS
     Mod.RegisterStateHook(EncoreIntro_PlayerInput_BuddySel, Player_Input_P1_Hook, true);
+    Mod.RegisterStateHook(OOZ2Outro_State_BoardSub, OOZ2Outro_State_BoardSub_Hook, true);
+    Mod.RegisterStateHook(OOZ2Outro_State_SubActivate, OOZ2Outro_State_SubActivate_Hook, true);
 #endif
 
     Mod.RegisterStateHook(BSS_Player_Input_P1, BSS_Player_Input_P1_Hook, true);
@@ -147,10 +152,8 @@ void InitModAPI(void)
     MOD_REGISTER_OBJ_OVERLOAD_MSV(PBL_Crane, Mod_PBL_Crane, PBL_Crane_Update, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     MOD_REGISTER_OBJ_OVERLOAD_MSV(PBL_Flipper, Mod_PBL_Flipper, NULL, NULL, PBL_Flipper_StaticUpdate, NULL, NULL, NULL, NULL, NULL, NULL);
     MOD_REGISTER_OBJ_OVERLOAD_MSV(PBL_Setup, Mod_PBL_Setup, NULL, NULL, PBL_Setup_StaticUpdate, NULL, NULL, NULL, NULL, NULL, NULL);
-#endif
 
-#if MANIA_USE_PLUS
-    MOD_REGISTER_OBJ_OVERLOAD_NOCLASS(CutsceneSeq, CutsceneSeq_Update, NULL, NULL, NULL, CutsceneSeq_Create, NULL, NULL, NULL, NULL);
+    MOD_REGISTER_OBJ_OVERLOAD(CutsceneSeq, CutsceneSeq_Update, NULL, NULL, NULL, CutsceneSeq_Create, NULL, NULL, NULL, NULL);
 #endif
 
     // Register Mod Callbacks
@@ -159,9 +162,6 @@ void InitModAPI(void)
     Mod.AddModCallback(MODCB_ONDRAW, DASetup_ModCB_OnDraw);
 
     // Get Public Functions
-#if MANIA_USE_PLUS
-    CutsceneSeq_CheckSkip  = Mod.GetPublicFunction(NULL, "CutsceneSeq_CheckSkip");
-#endif
     TitleSetup_VideoSkipCB = Mod.GetPublicFunction(NULL, "TitleSetup_VideoSkipCB");
     UIVideo_SkipCB         = Mod.GetPublicFunction(NULL, "UIVideo_SkipCB");
 }


### PR DESCRIPTION
OOZ2Outro uses its own function for skipping cutscenes. This PR adds function hooks to support the states that call this function. Fixes #12.