### PR TITLE
Fix GameAPI submodule path for `ExampleMod_CPP`, fix root namespace for `ExampleMod_C/CPP`

### DIFF
--- a/ExampleMod_C/ExampleMod/ExampleMod.vcxproj
+++ b/ExampleMod_C/ExampleMod/ExampleMod.vcxproj
@@ -22,7 +22,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{a7ddf156-9c7e-4867-8641-65dc61f3d1ce}</ProjectGuid>
-    <RootNamespace>DuckysDevTools</RootNamespace>
+    <RootNamespace>ExampleMod</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/ExampleMod_C/ExampleMod/dllmain.c
+++ b/ExampleMod_C/ExampleMod/dllmain.c
@@ -1,4 +1,4 @@
-#include "../GameAPI/C/GameAPI/Game.h"
+#include "GameAPI/Game.h"
 
 
 #if RETRO_USE_MOD_LOADER

--- a/ExampleMod_CPP/ExampleMod/ExampleMod.vcxproj
+++ b/ExampleMod_CPP/ExampleMod/ExampleMod.vcxproj
@@ -22,7 +22,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{a7ddf156-9c7e-4867-8641-65dc61f3d1ce}</ProjectGuid>
-    <RootNamespace>DuckysDevTools</RootNamespace>
+    <RootNamespace>ExampleMod</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -158,7 +158,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)GameAPI/C/</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)GameAPI/CPP/</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/ExampleMod_CPP/ExampleMod/dllmain.cpp
+++ b/ExampleMod_CPP/ExampleMod/dllmain.cpp
@@ -1,4 +1,4 @@
-#include "../GameAPI/CPP/GameAPI/Game.hpp"
+#include "GameAPI/Game.hpp"
 
 using namespace RSDK;
 


### PR DESCRIPTION
Fixes the submodule path for `ExampleMod_CPP`, as previously it redirected to C instead of CPP. Also changed the root namespace for both ExampleMod projects to `ExampleMod` instead of `DuckysDevTools`.